### PR TITLE
Fix: Tell the user why card type deletion fails when this would orphan note.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -36,6 +36,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
@@ -686,6 +687,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             }
 
             if (deletionWouldOrphanNote(col, tempModel, ordinal)) {
+                showOrphanNoteDialog()
                 return
             }
 
@@ -697,6 +699,18 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 0
             }
             confirmDeleteCards(template, tempModel.notetype, numAffectedCards)
+        }
+
+        /* showOrphanNoteDialog shows a AlertDialog if the deletionWouldOrphanNote returns true
+        * it displays a warning for the user when they attempt to delete a card type that
+            would leave some notes without any cards (orphan notes) */
+        private fun showOrphanNoteDialog() {
+            val builder = AlertDialog.Builder(requireContext())
+                .setTitle(R.string.orphan_note_title)
+                .setMessage(R.string.orphan_note_message)
+                .setPositiveButton(android.R.string.ok, null)
+
+            builder.show()
         }
 
         fun openBrowserAppearance(): Boolean {
@@ -869,7 +883,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                     // It is possible but unlikely that a user has an in-memory template addition that would
                     // generate cards making the deletion safe, but we don't handle that. All users who do
                     // not already have cards generated making it safe will see this error message:
-                    templateEditor.showSimpleMessageDialog(resources.getString(R.string.card_template_editor_would_delete_note))
+                    //   templateEditor.showSimpleMessageDialog(resources.getString(R.string.card_template_editor_would_delete_note)) // Implemented in the deleteCardTemplate
                     return true
                 }
             }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -423,4 +423,8 @@ opening the system text to speech settings fails">
     <string name="play_recording">Play</string>
     <string name="next_recording">Next</string>
 
+    <!--  AlertDialog in the deleteCardTemplate  -->
+    <string name="orphan_note_title">Cannot Delete Card Type</string>
+    <string name="orphan_note_message">Deleting this card type would leave notes without a card type. Please delete the notes first.</string>
+
 </resources>


### PR DESCRIPTION
## Purpose / Description
To show a dialog that tell users why card type deletion fails when this would orphan note.

## Fixes
* Fixes #16789

## Approach
The issue is ressolved by creating a AlertDialog that is show when the deletion of the current card type would orphan a note.

## How Has This Been Tested?

Device - Realme 10 pro+
Model - RMX3686
API Level - 34-ext12

## Screenshot of the fix

![orphanotefix](https://github.com/user-attachments/assets/db0e0f7b-f619-4904-8dd6-7847c80026c6)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
